### PR TITLE
fixed bad conditional in Combat.js -> findCombatant() that was breaking PvP

### DIFF
--- a/lib/Combat.js
+++ b/lib/Combat.js
@@ -176,7 +176,7 @@ class Combat {
       throw new CombatErrors.CombatSelfError("You smack yourself in the face. Ouch!");
     }
 
-    if (!target.hasBehavior('combat')) {
+    if (target.isNpc && !target.hasBehavior('combat')) {
       throw new CombatErrors.CombatPacifistError(`${target.name} is a pacifist and will not fight you.`, target);
     }
 


### PR DESCRIPTION
Added target.isNpc check before !target.hasBehavior("combat") check inside Combat.js:findCombatant() to make PvP work again. Before, when trying to attack another player, even when both had meta.pvp 
=== true set, you would only get the message "They aren't here," and combat wouldn't initiate.