### PR TITLE
Add consider help file

### DIFF
--- a/help/consider.yml
+++ b/help/consider.yml
@@ -1,0 +1,8 @@
+---
+command: consider
+body: |
+  Size up an enemy to see how difficult a fight against them would be.
+related:
+  - kill
+keywords:
+  - combat


### PR DESCRIPTION
This adds the `consider` help file, which was not copied over and is still in bundle-example-commands 

Should be deleted there also... maybe.. would that be a breaking change?